### PR TITLE
Address cross-origin and attachments security issues

### DIFF
--- a/netviel/api.py
+++ b/netviel/api.py
@@ -105,13 +105,15 @@ def create_app():
         else:
             f = io.BytesIO(d["content"])
         f.seek(0)
-        return send_file(f, mimetype=d["content_type"])
+        return send_file(f, mimetype=d["content_type"], as_attachment=True,
+            attachment_filename=d["filename"])
 
     @app.route("/api/message/<string:message_id>")
     def download_message(message_id):
         msgs = notmuch.Query(get_db(), "mid:{}".format(message_id)).search_messages()
         msg = next(msgs)  # there can be only 1
-        return send_file(msg.get_filename(), mimetype="message/rfc822")
+        return send_file(msg.get_filename(), mimetype="message/rfc822",
+            as_attachment=True, attachment_filename=message_id+".eml")
 
     return app
 
@@ -199,6 +201,7 @@ def message_attachment(message, num):
         return {}
     attachment = attachments[num]
     return {
+        "filename": attachment.get_filename(),
         "content_type": attachment.get_content_type(),
         "content": attachment.get_content(),
     }

--- a/netviel/api.py
+++ b/netviel/api.py
@@ -76,6 +76,14 @@ def create_app():
 
     app.teardown_appcontext(close_db)
 
+    @app.after_request
+    def security_headers(response):
+        response.headers["Cross-Origin-Resource-Policy"] = "same-origin"
+        response.headers["Cross-Origin-Opener-Policy"] = "same-origin"
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "SAMEORIGIN"
+        return response
+
     class Query(Resource):
         def get(self, query_string):
             threads = notmuch.Query(get_db(), query_string).search_threads()

--- a/netviel/api.py
+++ b/netviel/api.py
@@ -10,7 +10,6 @@ import os
 import bleach
 import notmuch
 from flask import Flask, current_app, g, send_file, send_from_directory
-from flask_cors import CORS
 from flask_restful import Api, Resource
 
 ALLOWED_TAGS = [
@@ -58,8 +57,6 @@ def create_app():
     app.config["PROPAGATE_EXCEPTIONS"] = True
     app.config["NOTMUCH_PATH"] = os.getenv("NOTMUCH_PATH")
     app.logger.setLevel(logging.INFO)
-
-    CORS(app)
 
     api = Api(app)
 

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setup(
     license="MIT",
     packages=find_packages(),
     package_data={"netviel": PACKAGE_DATA},
-    install_requires=["flask", "flask-restful", "flask-cors", "bleach"],
+    install_requires=["flask", "flask-restful", "bleach"],
 )


### PR DESCRIPTION
I found two major security issues:

1. with CORS enabled any website can read all emails simply by fetching the API endpoint on `127.0.0.1` (and without the new fancy CORB stuff, they can also do that via Spectre)

2. `text/html` attachments are served as web pages, allowing malicious emails to inject Javascript.

This set of patches should fix both (but I'm not actually a web security expert).